### PR TITLE
Some fixes in the API and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # `fc-ctl` - An **unofficial** CLI tool for Firecracker microVMs
 
-[`Firecrakcer`](https://github.com/firecracker-microvm/firecracker) is a Virtual Machine Monitor (VMM)
+[Firecrakcer](https://github.com/firecracker-microvm/firecracker) is a Virtual Machine Monitor (VMM)
 built on top of Linux KVM that allows running *microVMs*, i.e. normal KVM Virtual Machines with low
 boot-times and small attack surface and low resource utilization.
 
-`Firecracker` is configured through a RESTful API over a Unix Domain Socket (UDS). `fc-ctl` is a CLI tool
+Firecracker is configured through a RESTful API over a Unix Domain Socket (UDS). `fc-ctl` is a CLI tool
 for configuring, running & snapshotting Firecracker microVMs, based on top of [`fclib`](https://github.com/bchalios/fclib).
 It's main purpose is to use for testing.
 
@@ -12,3 +12,48 @@ The tool currently supports a subset of [Firecracker v1.4 API](https://github.co
 (mainly the things that are currently useful to me).
 
 Feel free to open an issue or PR for adding support for additional missing or broken features.
+
+## What `fc-ctl` is **NOT**
+
+A Firecracker SDK. It does not manage the lifecycle of the VMM processes. It assumes that Firecracker VMM is 
+launched and managed by other means. `fc-ctl` just speaks to a Firecracker process through its API server's
+UDS to configure and launch the microVM, or perform post-boot operations such as snapshotting.
+
+## Examples
+
+```
+# Configure a rootfs drive for microVM 
+cargo run -- --api-sock /tmp/fc.sock drive add vda /path/to/rootfs.ext4 --is-root-device
+
+# Configure a network device that uses tap device `tap0`.
+# Use a rate-limiter for TX queue that allows 100MB/s
+# and a rate-limiter for RX queue that allows 200MB/s
+cargo run -- --api-sock /tmp/fc.sock net add eth0 tap0 --tx-bw 10000000 100 --rx-bw 20000000 100
+
+# Configure the guest kernel and boot parameters
+cargo run -- --api-sock /tmp/fc.sock kernel /home/ec2-user/workspace/fc-cli/share/vmlinux --boot-args "panic=1 reboot=k tsc=reliable earlyprintk=ttyS0 console=ttyS0 ipv6.disable=1 pci=off"
+
+# Configure the microVM to have 1GB of memory and 4 vcpus
+cargo run -- --api-sock /tmp/fc.sock machine-config config 1024 4
+
+# Start the microVM
+cargo run -- --api-sock /tmp/fc.sock microvm start
+```
+
+For a full list of the supported commands you can:
+
+```
+cargo run -- help
+```
+
+and for more info on a particular command:
+
+```
+cargo run -- drive --help
+```
+
+or subcommand:
+
+```
+cargo run -- drive add --help
+```

--- a/src/drive.rs
+++ b/src/drive.rs
@@ -24,6 +24,7 @@ pub(crate) struct PartialDriveHelper {
     rate_limiter: RateLimiterConf,
 }
 
+/// Manage disks for microVM
 #[derive(Debug, Subcommand)]
 pub(crate) enum DriveCmd {
     Add(DriveHelper),

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -6,6 +6,7 @@ use fclib::client::ApiClient;
 use crate::rate_limiter::{RateLimiterConf, WithRateLimiterConf};
 use crate::Result;
 
+/// Configure microVM entropy device
 #[derive(Debug, Args)]
 pub(crate) struct EntropyArgs {
     #[clap(flatten)]

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,20 +1,17 @@
-use clap::Subcommand;
+use clap::Args;
 use fclib::client::kernel::BootSource;
 use fclib::client::ApiClient;
 
 use crate::Result;
 
-#[derive(Debug, Subcommand)]
-pub(crate) enum BootSourceCmd {
-    Set(BootSource),
+/// Configure microVM guest kernel
+#[derive(Debug, Args)]
+pub(crate) struct BootSourceArgs {
+    #[clap(flatten)]
+    kernel: BootSource,
 }
 
-impl BootSourceCmd {
-    pub(crate) async fn parse(&self, api_client: &mut ApiClient) -> Result<()> {
-        match self {
-            Self::Set(source) => api_client.set_boot_source(source).await?,
-        }
-
-        Ok(())
-    }
+pub(crate) async fn parse(api_client: &mut ApiClient, args: &BootSourceArgs) -> Result<()> {
+    api_client.set_boot_source(&args.kernel).await?;
+    Ok(())
 }

--- a/src/machine_config.rs
+++ b/src/machine_config.rs
@@ -1,20 +1,15 @@
-use clap::{Args, Subcommand};
+use clap::Subcommand;
 use fclib::client::vm::MachineConfiguration;
 use fclib::client::ApiClient;
 
 use crate::Result;
 
+/// Configure architectural characteristics of the microVM
 #[derive(Debug, Subcommand)]
 pub(crate) enum MachineConfigCmd {
     Config(MachineConfiguration),
     Get,
     Update(MachineConfiguration),
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct MachineConfigArgs {
-    drive_id: String,
-    drive_json: String,
 }
 
 impl MachineConfigCmd {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use clap::{Parser, Subcommand};
 use drive::DriveCmd;
 use entropy::EntropyArgs;
 use fclib::client::{ApiClient, FcClientError};
-use kernel::BootSourceCmd;
+use kernel::BootSourceArgs;
 use machine_config::MachineConfigCmd;
 use network::NetCommand;
 use snapshot::SnapshotCmd;
@@ -47,8 +47,7 @@ enum Commands {
     Net(NetCommand),
     #[command(subcommand)]
     MachineConfig(MachineConfigCmd),
-    #[command(subcommand)]
-    Kernel(BootSourceCmd),
+    Kernel(BootSourceArgs),
     #[command(subcommand)]
     Microvm(VmStateCmd),
     #[command(subcommand)]
@@ -65,7 +64,7 @@ async fn main() -> Result<()> {
         Commands::Drive(cmd) => cmd.parse(&mut api_client).await?,
         Commands::MachineConfig(cmd) => cmd.parse(&mut api_client).await?,
         Commands::Net(cmd) => cmd.parse(&mut api_client).await?,
-        Commands::Kernel(cmd) => cmd.parse(&mut api_client).await?,
+        Commands::Kernel(args) => kernel::parse(&mut api_client, &args).await?,
         Commands::Microvm(cmd) => cmd.parse(&api_client).await?,
         Commands::Snapshot(cmd) => cmd.parse(&api_client).await?,
         Commands::Entropy(args) => entropy::parse(&mut api_client, &args).await?,

--- a/src/network.rs
+++ b/src/network.rs
@@ -104,6 +104,7 @@ pub(crate) struct PartialNetworkInterfaceHelper {
     rate_limiter: NetRateLimiterConf,
 }
 
+/// Manage network interfaces for microVM
 #[derive(Debug, Subcommand)]
 pub(crate) enum NetCommand {
     /// Attach a new network interface to the microVM

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4,6 +4,7 @@ use fclib::client::ApiClient;
 
 use crate::Result;
 
+/// microVM snapshot operations
 #[derive(Debug, Subcommand)]
 pub(crate) enum SnapshotCmd {
     /// Create a microVM snapshot


### PR DESCRIPTION
Simplify `kernel` command. Since the only thing we can do is configure the guest kernel, there's no need for subcommands.

Also, fix the doc that `fc-ctl help` will show for top-level commands (it was missing in some cases) and add examples on how to use the tool for configuring and running a simple microVM